### PR TITLE
test: add agent-runner tool availability regression coverage

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -171,7 +171,7 @@ function buildMcpServers(mcpServerPath: string, containerInput: ContainerInput):
  * Tool names must match the SDK's internal lowercase names, not PascalCase.
  * Returning undefined allows all discovered tools (built-in + MCP).
  */
-function buildAvailableTools(): undefined {
+export function buildAvailableTools(): undefined {
   // Let the SDK expose all available tools — both built-in and MCP.
   // The SDK uses lowercase names (bash, edit, glob, grep, web_search, etc.)
   // and hyphenated MCP tool names (nanopielot-send_message, etc.).
@@ -183,7 +183,7 @@ function buildAvailableTools(): undefined {
  * Creates or resumes a session, sends the prompt, and collects the response.
  * Also polls IPC for follow-up messages during the query.
  */
-async function runQuery(
+export async function runQuery(
   client: CopilotClient,
   prompt: string,
   sessionId: string | undefined,
@@ -330,7 +330,14 @@ async function runScript(script: string): Promise<ScriptResult | null> {
   });
 }
 
-async function main(): Promise<void> {
+export function createCopilotClient(): CopilotClient {
+  return new CopilotClient({
+    logLevel: 'warning',
+    cwd: '/workspace/group',
+  });
+}
+
+export async function runAgentRunner(): Promise<void> {
   let containerInput: ContainerInput;
 
   try {
@@ -390,10 +397,7 @@ async function main(): Promise<void> {
   // via `copilot login`, and the SDK reuses that stored signed-in user state.
   // cwd must point to the group workspace so the CLI discovers AGENTS.md
   // and project-level settings from the working directory.
-  const client = new CopilotClient({
-    logLevel: 'warning',
-    cwd: '/workspace/group',
-  });
+  const client = createCopilotClient();
 
   try {
     // Query loop: run query → wait for IPC message → run new query → repeat
@@ -445,4 +449,11 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+const entrypointPath = process.argv[1]
+  ? path.resolve(process.cwd(), process.argv[1])
+  : undefined;
+const modulePath = fileURLToPath(import.meta.url);
+
+if (entrypointPath === modulePath) {
+  void runAgentRunner();
+}

--- a/src/agent-runner.e2e.test.ts
+++ b/src/agent-runner.e2e.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+const sdkMocks = vi.hoisted(() => {
+  type PermissionHandler = (request: unknown) => Promise<unknown>;
+  type SessionBehaviorArgs = {
+    config: Record<string, unknown>;
+    session: FakeSession;
+    prompt: string;
+    timeout: number;
+  };
+
+  const state = {
+    approveAllMock: vi.fn<PermissionHandler>(async (request) => ({
+      status: 'approved',
+      request,
+    })),
+    clientOptions: [] as Array<Record<string, unknown>>,
+    createdConfigs: [] as Array<Record<string, unknown>>,
+    resumedConfigs: [] as Array<{ sessionId: string; config: Record<string, unknown> }>,
+    stopMock: vi.fn(async () => {}),
+    sessionBehavior: undefined as
+      | ((args: SessionBehaviorArgs) => Promise<void> | void)
+      | undefined,
+  };
+
+  class FakeSession {
+    sessionId: string;
+    private handlers: Array<(event: { type: string; data?: unknown }) => void> = [];
+
+    constructor(
+      readonly config: Record<string, unknown>,
+      sessionId: string,
+    ) {
+      this.sessionId = sessionId;
+    }
+
+    on(handler: (event: { type: string; data?: unknown }) => void): void {
+      this.handlers.push(handler);
+    }
+
+    emit(event: { type: string; data?: unknown }): void {
+      for (const handler of this.handlers) {
+        handler(event);
+      }
+    }
+
+    async sendAndWait(
+      { prompt }: { prompt: string },
+      timeout: number,
+    ): Promise<{ data: { content: string } }> {
+      await state.sessionBehavior?.({
+        config: this.config,
+        session: this,
+        prompt,
+        timeout,
+      });
+      return { data: { content: 'Tool-backed response' } };
+    }
+
+    async send(): Promise<void> {}
+
+    async abort(): Promise<void> {}
+  }
+
+  class FakeCopilotClient {
+    constructor(options: Record<string, unknown>) {
+      state.clientOptions.push(options);
+    }
+
+    async createSession(config: Record<string, unknown>): Promise<FakeSession> {
+      state.createdConfigs.push(config);
+      return new FakeSession(config, 'new-session-id');
+    }
+
+    async resumeSession(
+      sessionId: string,
+      config: Record<string, unknown>,
+    ): Promise<FakeSession> {
+      state.resumedConfigs.push({ sessionId, config });
+      return new FakeSession(config, sessionId);
+    }
+
+    async stop(): Promise<void> {
+      await state.stopMock();
+    }
+  }
+
+  return {
+    FakeCopilotClient,
+    reset(): void {
+      state.approveAllMock.mockClear();
+      state.clientOptions.length = 0;
+      state.createdConfigs.length = 0;
+      state.resumedConfigs.length = 0;
+      state.stopMock.mockClear();
+      state.sessionBehavior = undefined;
+    },
+    setSessionBehavior(
+      behavior: (args: SessionBehaviorArgs) => Promise<void> | void,
+    ): void {
+      state.sessionBehavior = behavior;
+    },
+    state,
+  };
+});
+
+vi.mock('@github/copilot-sdk', () => ({
+  CopilotClient: sdkMocks.FakeCopilotClient,
+  approveAll: sdkMocks.state.approveAllMock,
+}));
+
+async function loadAgentRunnerModule() {
+  return import(
+    pathToFileURL(
+      path.resolve(process.cwd(), 'container/agent-runner/src/index.ts'),
+    ).href
+  );
+}
+
+const testContainerInput = {
+  prompt: 'Find the latest tech news',
+  groupFolder: 'telegram_main',
+  chatJid: 'tg:123',
+  isMain: true,
+};
+
+describe('agent-runner tool availability', () => {
+  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleErrorSpy = vi
+    .spyOn(console, 'error')
+    .mockImplementation(() => {});
+  const setTimeoutSpy = vi
+    .spyOn(global, 'setTimeout')
+    .mockImplementation(() => 0 as unknown as ReturnType<typeof setTimeout>);
+
+  beforeEach(() => {
+    vi.resetModules();
+    sdkMocks.reset();
+    consoleLogSpy.mockClear();
+    consoleErrorSpy.mockClear();
+    setTimeoutSpy.mockClear();
+    sdkMocks.setSessionBehavior(async ({ config, session, prompt, timeout }) => {
+      expect(prompt).toBe(testContainerInput.prompt);
+      expect(timeout).toBe(10 * 60 * 1000);
+
+      if (Object.prototype.hasOwnProperty.call(config, 'availableTools')) {
+        session.emit({
+          type: 'session.info',
+          data: {
+            infoType: 'configuration',
+            message: 'Disabled tools: bash, edit, glob',
+          },
+        });
+      } else {
+        session.emit({
+          type: 'session.tools_updated',
+          data: {
+            tools: [{ name: 'bash' }, { name: 'web_search' }],
+          },
+        });
+      }
+
+      const permissionHandler = config.onPermissionRequest as
+        | ((request: unknown) => Promise<unknown>)
+        | undefined;
+      await permissionHandler?.({
+        kind: 'shell',
+        toolCallId: 'tool-1',
+        fullCommandText: 'echo hello',
+      });
+
+      session.emit({
+        type: 'tool.execution_start',
+        data: { toolName: 'bash' },
+      });
+      session.emit({ type: 'session.idle' });
+    });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockClear();
+    consoleErrorSpy.mockClear();
+    setTimeoutSpy.mockClear();
+  });
+
+  it('creates Copilot clients with the workspace cwd', async () => {
+    const { createCopilotClient } = await loadAgentRunnerModule();
+    createCopilotClient();
+
+    expect(sdkMocks.state.clientOptions).toEqual([
+      {
+        logLevel: 'warning',
+        cwd: '/workspace/group',
+      },
+    ]);
+  });
+
+  it('creates sessions without a restrictive availableTools allowlist', async () => {
+    const { createCopilotClient, runQuery } = await loadAgentRunnerModule();
+    const client = createCopilotClient();
+
+    const result = await runQuery(
+      client,
+      testContainerInput.prompt,
+      undefined,
+      '/tmp/ipc-mcp-stdio.js',
+      testContainerInput,
+    );
+
+    expect(result).toEqual({
+      newSessionId: 'new-session-id',
+      closedDuringQuery: false,
+    });
+    expect(sdkMocks.state.createdConfigs).toHaveLength(1);
+
+    const config = sdkMocks.state.createdConfigs[0];
+    expect(config).not.toHaveProperty('availableTools');
+    expect(config.workingDirectory).toBe('/workspace/group');
+    expect(config.mcpServers).toMatchObject({
+      nanopielot: {
+        command: 'node',
+        args: ['/tmp/ipc-mcp-stdio.js'],
+        env: {
+          NANOPIELOT_CHAT_JID: 'tg:123',
+          NANOPIELOT_GROUP_FOLDER: 'telegram_main',
+          NANOPIELOT_IS_MAIN: '1',
+        },
+        tools: ['*'],
+      },
+    });
+
+    const errorOutput = consoleErrorSpy.mock.calls.flat().join('\n');
+    expect(errorOutput).toContain('[agent-runner] [event] session.tools_updated');
+    expect(errorOutput).not.toContain('Disabled tools');
+  });
+
+  it('wires approveAll into tool-backed queries', async () => {
+    const { createCopilotClient, runQuery } = await loadAgentRunnerModule();
+    const client = createCopilotClient();
+
+    await runQuery(
+      client,
+      testContainerInput.prompt,
+      undefined,
+      '/tmp/ipc-mcp-stdio.js',
+      testContainerInput,
+    );
+
+    expect(sdkMocks.state.approveAllMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'shell',
+        toolCallId: 'tool-1',
+        fullCommandText: 'echo hello',
+      }),
+    );
+  });
+
+  it('resumes persisted sessions with the same safe config', async () => {
+    const { createCopilotClient, runQuery } = await loadAgentRunnerModule();
+    const client = createCopilotClient();
+
+    await runQuery(
+      client,
+      testContainerInput.prompt,
+      'persisted-session-id',
+      '/tmp/ipc-mcp-stdio.js',
+      testContainerInput,
+    );
+
+    expect(sdkMocks.state.createdConfigs).toHaveLength(0);
+    expect(sdkMocks.state.resumedConfigs).toEqual([
+      {
+        sessionId: 'persisted-session-id',
+        config: expect.objectContaining({
+          workingDirectory: '/workspace/group',
+          mcpServers: expect.any(Object),
+        }),
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add import-safe test seams for the container agent-runner
- cover workspace cwd setup, unrestricted tool exposure, `approveAll` wiring, and session resume config
- prevent regressions where a restrictive tool allowlist silently disables all tools

## Testing
- `npm run build`
- `npm test`

Closes #1
