### PR TITLE
docs: add changelog compare and release links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,6 @@ All notable changes to NanoPieLot will be documented in this file.
 - Authentication via `copilot login` device flow (no API keys).
 - Live model switching with `/model` command per group.
 - All NanoClaw features preserved: containers, channels, skills, scheduling, agent swarms.
+
+[1.1.0]: https://github.com/trsdn/nanopielot/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/trsdn/nanopielot/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary
- add GitHub compare/release links for changelog versions
- make the existing version headings clickable via reference-style links
- align the changelog with Keep a Changelog linking conventions

## Testing
- `npm run build`
- `npm test`

Closes #6
