### PR TITLE
feat: surface agent-runner tool configuration warnings

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -70,6 +70,57 @@ function log(message: string): void {
   console.error(`[agent-runner] ${message}`);
 }
 
+interface ToolConfigurationWarning {
+  disabledTools?: string[];
+  unknownTools?: string[];
+}
+
+function parseToolList(value: string): string[] {
+  return value
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
+export function parseToolConfigurationWarning(
+  message: string,
+): ToolConfigurationWarning | null {
+  const disabledMatch = message.match(/^Disabled tools:\s*(.+)$/i);
+  if (disabledMatch) {
+    return { disabledTools: parseToolList(disabledMatch[1]) };
+  }
+
+  const unknownMatch = message.match(
+    /^Unknown tool name(?: in the tool allowlist)?:\s*(.+)$/i,
+  );
+  if (unknownMatch) {
+    return { unknownTools: parseToolList(unknownMatch[1]) };
+  }
+
+  if (message.includes('Unknown tool name')) {
+    return { unknownTools: [] };
+  }
+
+  return null;
+}
+
+function logToolConfigurationWarning(message: string): void {
+  const warning = parseToolConfigurationWarning(message);
+  if (!warning) return;
+
+  log('WARNING: Tool configuration issue detected. Check availableTools and MCP tool registration.');
+  if (warning.disabledTools && warning.disabledTools.length > 0) {
+    log(`Disabled tools: ${warning.disabledTools.join(', ')}`);
+  }
+  if (warning.unknownTools) {
+    if (warning.unknownTools.length > 0) {
+      log(`Unknown tool names: ${warning.unknownTools.join(', ')}`);
+    } else {
+      log(`Unknown tool names reported by SDK: ${message}`);
+    }
+  }
+}
+
 /**
  * Check for _close sentinel.
  */
@@ -244,8 +295,24 @@ export async function runQuery(
   setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
 
   // Subscribe to events for logging
+  const seenToolConfigWarnings = new Set<string>();
   session.on((event) => {
     if (event.type === 'assistant.message_delta') return; // too noisy
+    if (event.type === 'session.info') {
+      const data =
+        event.data && typeof event.data === 'object'
+          ? (event.data as Record<string, unknown>)
+          : null;
+      const infoType = data?.infoType;
+      const message = data?.message;
+      if (infoType === 'configuration' && typeof message === 'string') {
+        const warning = parseToolConfigurationWarning(message);
+        if (warning && !seenToolConfigWarnings.has(message)) {
+          seenToolConfigWarnings.add(message);
+          logToolConfigurationWarning(message);
+        }
+      }
+    }
     log(`[event] ${event.type}`);
   });
 

--- a/src/agent-runner.e2e.test.ts
+++ b/src/agent-runner.e2e.test.ts
@@ -236,6 +236,75 @@ describe('agent-runner tool availability', () => {
     expect(errorOutput).not.toContain('Disabled tools');
   });
 
+  it('parses disabled and unknown tool configuration warnings', async () => {
+    const { parseToolConfigurationWarning } = await loadAgentRunnerModule();
+
+    expect(
+      parseToolConfigurationWarning('Disabled tools: bash, edit, glob'),
+    ).toEqual({
+      disabledTools: ['bash', 'edit', 'glob'],
+    });
+    expect(
+      parseToolConfigurationWarning(
+        'Unknown tool name in the tool allowlist: Bash, Read',
+      ),
+    ).toEqual({
+      unknownTools: ['Bash', 'Read'],
+    });
+    expect(
+      parseToolConfigurationWarning('Configuration loaded successfully'),
+    ).toBeNull();
+  });
+
+  it('logs clear warnings for disabled tools and unknown allowlist names', async () => {
+    const { createCopilotClient, runQuery } = await loadAgentRunnerModule();
+    const client = createCopilotClient();
+    sdkMocks.setSessionBehavior(async ({ session }) => {
+      session.emit({
+        type: 'session.info',
+        data: {
+          infoType: 'configuration',
+          message: 'Disabled tools: bash, edit, glob',
+        },
+      });
+      session.emit({
+        type: 'session.info',
+        data: {
+          infoType: 'configuration',
+          message: 'Unknown tool name in the tool allowlist: Bash, Read',
+        },
+      });
+      session.emit({
+        type: 'session.info',
+        data: {
+          infoType: 'configuration',
+          message: 'Disabled tools: bash, edit, glob',
+        },
+      });
+      session.emit({ type: 'session.idle' });
+    });
+
+    await runQuery(
+      client,
+      testContainerInput.prompt,
+      undefined,
+      '/tmp/ipc-mcp-stdio.js',
+      testContainerInput,
+    );
+
+    const errorOutput = consoleErrorSpy.mock.calls.flat().join('\n');
+    expect(errorOutput).toContain(
+      '[agent-runner] WARNING: Tool configuration issue detected. Check availableTools and MCP tool registration.',
+    );
+    expect(errorOutput).toContain('[agent-runner] Disabled tools: bash, edit, glob');
+    expect(errorOutput).toContain('[agent-runner] Unknown tool names: Bash, Read');
+    expect(
+      consoleErrorSpy.mock.calls.filter((call) =>
+        call.join('\n').includes('Disabled tools: bash, edit, glob'),
+      ),
+    ).toHaveLength(1);
+  });
+
   it('wires approveAll into tool-backed queries', async () => {
     const { createCopilotClient, runQuery } = await loadAgentRunnerModule();
     const client = createCopilotClient();


### PR DESCRIPTION
## Summary

- parse `session.info` configuration warnings for disabled tools and unknown tool names
- emit clear deduplicated warning logs so tool configuration problems are visible immediately
- cover the warning parser and event logging with agent-runner regression tests

## Testing
- npx vitest run src/agent-runner.e2e.test.ts
- npm run build && npm test
