### PR TITLE
docs: prepare v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to NanoPieLot will be documented in this file.
 
+## [1.2.0]
+
+### Added
+
+- **Agent-runner regression coverage** — added end-to-end-style tests around Copilot client setup, tool availability, permission wiring, session resume behavior, stale-session fallback, and tool-configuration warnings.
+- **Migration guide** — added `docs/MIGRATION.md` with NanoClaw -> NanoPieLot migration notes for Copilot SDK, device login, AGENTS discovery, and related compatibility details.
+- **Troubleshooting guide** — added `docs/TROUBLESHOOTING.md` covering tool allowlist issues, stale builds, Copilot auth problems, Docker cache problems, and the Copilot SDK upgrade workflow.
+
+### Changed
+
+- **Bootstrap vs. app runtime split** — extracted the main runtime and service logic into `src/app.ts`, leaving `src/index.ts` as a thin bootstrapper and re-export surface for future API/Web UI entrypoints.
+- **Changelog navigation** — added compare/release links so version entries can link directly to GitHub release pages and diffs.
+
+### Fixed
+
+- **Pinned Copilot SDK usage** — pinned `@github/copilot-sdk` to exact `0.2.1` and added an agent-runner startup warning if the loaded SDK version drifts from the pinned version.
+- **Safer session resume** — the agent-runner now checks `getSessionMetadata()` before `resumeSession()` and creates a fresh session when a persisted session ID no longer exists.
+- **Tool configuration visibility** — the agent-runner now logs clear warnings when the SDK reports disabled tools or unknown tool names.
+- **Safer `/model` parsing** — replaced the regex-based `/model` command parsing path with direct string parsing to avoid the GitHub Advanced Security CodeQL finding on uncontrolled input.
+
 ## [1.1.0]
 
 ### Fixed
@@ -18,5 +38,6 @@ All notable changes to NanoPieLot will be documented in this file.
 - Live model switching with `/model` command per group.
 - All NanoClaw features preserved: containers, channels, skills, scheduling, agent swarms.
 
+[1.2.0]: https://github.com/trsdn/nanopielot/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/trsdn/nanopielot/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/trsdn/nanopielot/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

- prepare the v1.2.0 release notes in CHANGELOG.md
- summarize the merged milestone work from issues #1, #2, #3, #4, #5, #6, #7, and #9
- add the v1.2.0 compare link for the upcoming release tag

