### PR TITLE
security: remove regex-based warning parsing

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -88,19 +88,44 @@ function parseToolList(value: string): string[] {
     .filter(Boolean);
 }
 
+function startsWithIgnoreCase(value: string, prefix: string): boolean {
+  return value.length >= prefix.length
+    && value.slice(0, prefix.length).toLowerCase() === prefix.toLowerCase();
+}
+
+function parseWarningValue(
+  message: string,
+  prefix: string,
+): string | undefined {
+  if (!startsWithIgnoreCase(message, prefix)) {
+    return undefined;
+  }
+
+  const value = message.slice(prefix.length).trim();
+  return value.length > 0 ? value : undefined;
+}
+
 export function parseToolConfigurationWarning(
   message: string,
 ): ToolConfigurationWarning | null {
-  const disabledMatch = message.match(/^Disabled tools:\s*(.+)$/i);
-  if (disabledMatch) {
-    return { disabledTools: parseToolList(disabledMatch[1]) };
+  const disabledTools = parseWarningValue(message, 'Disabled tools:');
+  if (disabledTools) {
+    return { disabledTools: parseToolList(disabledTools) };
   }
 
-  const unknownMatch = message.match(
-    /^Unknown tool name(?: in the tool allowlist)?:\s*(.+)$/i,
-  );
-  if (unknownMatch) {
-    return { unknownTools: parseToolList(unknownMatch[1]) };
+  const unknownPrefixes = [
+    'Unknown tool name in the tool allowlist:',
+    'Unknown tool name:',
+  ];
+  let unknownTools: string | undefined;
+  for (const prefix of unknownPrefixes) {
+    unknownTools = parseWarningValue(message, prefix);
+    if (unknownTools) {
+      break;
+    }
+  }
+  if (unknownTools) {
+    return { unknownTools: parseToolList(unknownTools) };
   }
 
   if (message.includes('Unknown tool name')) {


### PR DESCRIPTION
## Summary
- replace regex-based parsing in `parseToolConfigurationWarning` with simple prefix parsing
- preserve the disabled-tools and unknown-tool warning behavior
- remove the CodeQL ReDoS trigger in the agent-runner warning parser

## Validation
- npm run build
- npm test -- src/agent-runner.e2e.test.ts -t "parses disabled and unknown tool configuration warnings"
- cd container/agent-runner && npm run build
- cd container/agent-runner && npm audit

Closes #25