### PR TITLE
security: remove shell-interpolated setup commands

### DIFF
--- a/setup/groups.ts
+++ b/setup/groups.ts
@@ -4,7 +4,7 @@
  * Other channels discover group names at runtime — this step auto-skips for them.
  * Replaces 05-sync-groups.sh + 05b-list-groups.sh
  */
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -182,7 +182,7 @@ sock.ev.on('connection.update', async (update) => {
     const tmpScript = path.join(projectRoot, '.tmp-group-sync.mjs');
     fs.writeFileSync(tmpScript, syncScript, 'utf-8');
     try {
-      const output = execSync(`node ${tmpScript}`, {
+      const output = execFileSync('node', [tmpScript], {
         cwd: projectRoot,
         encoding: 'utf-8',
         timeout: 45000,

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -4,7 +4,7 @@
  *
  * Fixes: Root→system systemd, WSL nohup fallback, no `|| true` swallowing errors.
  */
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -165,7 +165,7 @@ function setupLinux(
  */
 function killOrphanedProcesses(projectRoot: string): void {
   try {
-    execSync(`pkill -f '${projectRoot}/dist/index\\.js' || true`, {
+    execFileSync('pkill', ['-f', `${projectRoot}/dist/index\\.js`], {
       stdio: 'ignore',
     });
     logger.info('Stopped any orphaned nanopielot processes');


### PR DESCRIPTION
## Summary
- replace `execSync(`node `)` with `execFileSync('node', [tmpScript])`
- replace the shell-based `pkill -f ...` call with argument-based `execFileSync`
- keep existing setup behavior while removing the CodeQL shell-injection pattern

## Validation
- npm run build
- npm test -- setup/register.test.ts setup/platform.test.ts setup/environment.test.ts

Closes #24